### PR TITLE
ci: run application checks on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: |
           pnpm --dir frontend install --frozen-lockfile
           pnpm --dir scripts/qa/e2e install --frozen-lockfile
-          pnpm --dir scripts/qa/e2e exec playwright install webkit
+          pnpm --dir scripts/qa/e2e exec playwright-core install webkit
       - name: Rust static analysis (default and StoreKit)
         working-directory: backend
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,126 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: Frontend
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+      - run: pnpm install --frozen-lockfile
+        working-directory: frontend
+      - name: Typecheck and production build
+        run: pnpm build
+        working-directory: frontend
+      - run: pnpm test
+        working-directory: frontend
+
+  macos:
+    name: macOS / Rust, Swift and E2E
+    runs-on: macos-15
+    timeout-minutes: 60
+    env:
+      CARGO_TERM_COLOR: always
+      # DataFusion's debug symbols exceed the hosted runner's disk budget.
+      CARGO_PROFILE_DEV_DEBUG: '0'
+      CARGO_PROFILE_TEST_DEBUG: '0'
+      CARGO_INCREMENTAL: '0'
+      DEV_URL: http://localhost:1421/
+      BRIDGE_QUIET: '1'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.13.1
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          cache: pnpm
+          cache-dependency-path: |
+            frontend/pnpm-lock.yaml
+            scripts/qa/e2e/pnpm-lock.yaml
+      - name: Rust toolchain
+        run: |
+          rustup toolchain install 1.91.1 --profile minimal --component clippy
+          rustup default 1.91.1
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: backend
+      - uses: astral-sh/setup-uv@v7
+      - name: Install frontend and browser harness
+        run: |
+          pnpm --dir frontend install --frozen-lockfile
+          pnpm --dir scripts/qa/e2e install --frozen-lockfile
+          pnpm --dir scripts/qa/e2e exec playwright install webkit
+      - name: Rust static analysis (default and StoreKit)
+        working-directory: backend
+        run: |
+          cargo clippy --locked --all-targets -- -D warnings
+          cargo clippy --locked --all-targets --features app-store -- -D warnings
+      - name: Rust tests (default and StoreKit)
+        working-directory: backend
+        run: |
+          cargo test --locked --lib
+          cargo test --locked --lib --features app-store
+      - name: Check generated IPC bindings
+        run: |
+          git diff --exit-code -- frontend/src/bindings/ipc
+          test -z "$(git ls-files --others --exclude-standard frontend/src/bindings/ipc)"
+      - name: Swift payload tests
+        run: swift test --package-path backend/storekit
+      - name: Build E2E backend
+        working-directory: backend
+        run: cargo build --locked --example bridge
+      - name: Build production frontend
+        run: pnpm --dir frontend build
+      - name: Generate adversarial fixtures
+        run: uv run scripts/qa/gen_fixtures.py
+      - name: Browser error gate and regression suite under CSP
+        shell: bash
+        run: |
+          node scripts/qa/e2e/csp-server.mjs > "$RUNNER_TEMP/csp-server.log" 2>&1 &
+          server_pid=$!
+          trap 'kill "$server_pid" 2>/dev/null || true' EXIT
+          for attempt in {1..60}; do
+            if curl --fail --silent "$DEV_URL" > /dev/null; then break; fi
+            kill -0 "$server_pid"
+            sleep 1
+          done
+          curl --fail --silent "$DEV_URL" > /dev/null
+          pnpm --dir scripts/qa/e2e test
+          pnpm --dir scripts/qa/e2e suite
+      - name: E2E diagnostics
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-results
+          retention-days: 7
+          path: |
+            scripts/qa/e2e/out/suite_results.json
+            scripts/qa/e2e/out/shots/
+            ${{ runner.temp }}/csp-server.log

--- a/README.md
+++ b/README.md
@@ -128,13 +128,28 @@ certificate, for a look at what the store gets.
 ### Tests
 
 ```bash
-cd frontend && pnpm test        # Vitest
-cd backend  && cargo test --lib # Rust unit tests
+pnpm --dir frontend test                   # Vitest (run these from repo root)
+(cd backend && cargo test --lib)           # Rust unit tests
+swift test --package-path backend/storekit # Swift payload tests
 ```
 
 `scripts/qa/e2e/` drives the real backend through Playwright WebKit (see its
 README), `docs/MANUAL_QA.md` holds what only the macOS shell can show, and
 `site/` is the product page published to GitHub Pages.
+
+Pull requests and pushes to `main` run [CI](.github/workflows/ci.yml):
+the frontend's typecheck, production build and tests; Rust Clippy and tests
+with and without `app-store`; Swift payload tests; generated IPC binding
+drift detection; and the WebKit regression suite against the built frontend
+under the release CSP. The browser error gate is itself tested by injecting
+exceptions and CSP violations. E2E results and screenshots are kept as the
+`e2e-results` artifact for seven days.
+
+The native checks run on macOS; signing, store uploads and the real StoreKit
+purchase sheet remain part of release QA. CI does not enforce `cargo fmt`
+yet because the existing Rust tree has formatting differences. Making these
+jobs required for merging is a separate repository ruleset setting; merely
+adding the workflow does not enable branch protection.
 
 ## How it is put together
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,12 @@ exceptions and CSP violations. E2E results and screenshots are kept as the
 `e2e-results` artifact for seven days.
 
 The native checks run on macOS; signing, store uploads and the real StoreKit
-purchase sheet remain part of release QA. CI does not enforce `cargo fmt`
+purchase sheet remain part of release QA. CI checks the actual Rust/Swift ABI
+through invalid product input (no store request), callback payload ownership and
+parsing, and Swift JSON delivery. The three live StoreKit smoke tests are opt-in:
+`cd backend && cargo test --locked --lib --features app-store services::store::storekit::tests -- --ignored`.
+Run them in a working App Store environment; they still fail on timeout. An
+unsigned hosted runner can stall while reading `Transaction.currentEntitlements`. CI does not enforce `cargo fmt`
 yet because the existing Rust tree has formatting differences. Making these
 jobs required for merging is a separate repository ruleset setting; merely
 adding the workflow does not enable branch protection.

--- a/backend/src/services/store/storekit.rs
+++ b/backend/src/services/store/storekit.rs
@@ -140,11 +140,48 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
-    /// The bridge round trip itself: the call reaches Swift, Swift calls
-    /// back from its own thread, the strings are copied out and parsed. An
-    /// unsigned test binary has no App Store, so the answer may be an
-    /// empty list or an error — either proves the ABI; a hang would not.
+    /// Exercise the real Swift entry point and detached-task callback without
+    /// asking StoreKit or requiring a signed app / App Store account.
     #[tokio::test]
+    async fn invalid_product_ids_round_trip_through_swift() {
+        for raw in ["not JSON", "{}", "[1]"] {
+            let ids = c_string(raw).unwrap();
+            let reply = tokio::time::timeout(
+                Duration::from_secs(5),
+                call(|ctx, cb| unsafe { sk_load_products(ids.as_ptr(), ctx, cb) }),
+            )
+            .await
+            .expect("Swift never called back");
+            assert_eq!(reply.unwrap_err(), "product ids must be a JSON array of strings");
+        }
+    }
+
+    /// Callback strings are borrowed only during the call. Parse after the
+    /// source CString is dropped to check that Rust owns the copied payload.
+    #[tokio::test]
+    async fn callback_copies_and_parses_entitlements() {
+        let reply = call(|ctx, cb| {
+            let json = c_string(r#"[{"product_id":"parqsee.full","original_purchase_date":123,"purchase_date":456}]"#).unwrap();
+            cb(ctx, json.as_ptr(), std::ptr::null());
+        }).await.unwrap();
+        let list: Vec<Entitlement> = parse(&reply).unwrap();
+        assert_eq!(list.len(), 1);
+        assert_eq!(list[0].product_id, "parqsee.full");
+        assert_eq!(list[0].original_purchase_date, 123);
+        assert_eq!(list[0].purchase_date, 456);
+    }
+
+    #[tokio::test]
+    async fn callback_without_a_payload_is_an_error() {
+        let reply = call(|ctx, cb| cb(ctx, std::ptr::null(), std::ptr::null())).await;
+        assert_eq!(reply.unwrap_err(), "the App Store bridge returned nothing");
+    }
+
+    /// Live StoreKit smoke tests are opt-in: an unsigned hosted runner is
+    /// not guaranteed to receive a response from the App Store services.
+    /// They retain strict timeouts when explicitly run in a store environment.
+    #[tokio::test]
+    #[ignore = "requires a working App Store environment; run explicitly with --ignored"]
     async fn entitlements_round_trip_through_swift() {
         let reply = tokio::time::timeout(Duration::from_secs(30), SwiftStore.entitlements())
             .await
@@ -155,12 +192,8 @@ mod tests {
         }
     }
 
-    /// `sk_restore`'s ABI: the call reaches Swift and comes back. Without an
-    /// App Store `AppStore.sync()` fails, so this only ever sees the error
-    /// path — what the successful one *encodes* is covered in Swift, by
-    /// `ParqseeStoreKitTests` (`swift test --package-path storekit`), since
-    /// no test binary can make the store answer.
     #[tokio::test]
+    #[ignore = "requires a working App Store environment; run explicitly with --ignored"]
     async fn restore_round_trip_through_swift() {
         let reply = tokio::time::timeout(Duration::from_secs(30), SwiftStore.restore())
             .await
@@ -171,6 +204,7 @@ mod tests {
     }
 
     #[tokio::test]
+    #[ignore = "requires a working App Store environment; run explicitly with --ignored"]
     async fn products_of_an_unknown_store_come_back_as_a_list_or_an_error() {
         let reply = tokio::time::timeout(
             Duration::from_secs(30),

--- a/backend/storekit/Sources/ParqseeStoreKit/Bridge.swift
+++ b/backend/storekit/Sources/ParqseeStoreKit/Bridge.swift
@@ -59,7 +59,7 @@ enum Encoded: Equatable {
     case refused(String)
 }
 
-private func deliver(_ ctx: UnsafeMutableRawPointer?, _ cb: SKCallback, json: Any) {
+func deliver(_ ctx: UnsafeMutableRawPointer?, _ cb: SKCallback, json: Any) {
     switch encodeJSON(json) {
     case .json(let text):
         text.withCString { cb(ctx, $0, nil) }
@@ -68,7 +68,7 @@ private func deliver(_ ctx: UnsafeMutableRawPointer?, _ cb: SKCallback, json: An
     }
 }
 
-private func deliver(_ ctx: UnsafeMutableRawPointer?, _ cb: SKCallback, error: String) {
+func deliver(_ ctx: UnsafeMutableRawPointer?, _ cb: SKCallback, error: String) {
     error.withCString { cb(ctx, nil, $0) }
 }
 

--- a/backend/storekit/Tests/ParqseeStoreKitTests/DeliveryTests.swift
+++ b/backend/storekit/Tests/ParqseeStoreKitTests/DeliveryTests.swift
@@ -1,0 +1,48 @@
+@testable import ParqseeStoreKit
+import Foundation
+import XCTest
+
+private final class Reply {
+    var calls = 0
+    var json: String?
+    var error: String?
+}
+
+private let capture: SKCallback = { ctx, json, error in
+    let reply = Unmanaged<Reply>.fromOpaque(ctx!).takeUnretainedValue()
+    reply.calls += 1
+    reply.json = json.map { String(cString: $0) }
+    reply.error = error.map { String(cString: $0) }
+}
+
+final class DeliveryTests: XCTestCase {
+    func testDeliversSuccessPayloadsExactlyOnce() {
+        for (payload, expected) in [
+            ([String: Any]() as Any, "{}"),
+            ([[String: Any]]() as Any, "[]"),
+            (["outcome": "purchased"] as Any, #"{"outcome":"purchased"}"#),
+        ] {
+            let reply = Reply()
+            deliver(Unmanaged.passUnretained(reply).toOpaque(), capture, json: payload)
+            XCTAssertEqual(reply.calls, 1)
+            XCTAssertEqual(reply.json, expected)
+            XCTAssertNil(reply.error)
+        }
+    }
+
+    func testDeliversEncodingFailureExactlyOnce() {
+        let reply = Reply()
+        deliver(Unmanaged.passUnretained(reply).toOpaque(), capture, json: NSNull())
+        XCTAssertEqual(reply.calls, 1)
+        XCTAssertNil(reply.json)
+        XCTAssertTrue(reply.error?.contains("not a JSON array or object") == true)
+    }
+
+    func testDeliversAnExplicitErrorExactlyOnce() {
+        let reply = Reply()
+        deliver(Unmanaged.passUnretained(reply).toOpaque(), capture, error: "store unavailable")
+        XCTAssertEqual(reply.calls, 1)
+        XCTAssertNil(reply.json)
+        XCTAssertEqual(reply.error, "store unavailable")
+    }
+}

--- a/backend/storekit/Tests/ParqseeStoreKitTests/EncodeJSONTests.swift
+++ b/backend/storekit/Tests/ParqseeStoreKitTests/EncodeJSONTests.swift
@@ -1,8 +1,3 @@
-// The payload encoding of the bridge's callbacks, which nothing else can
-// reach: every C entry point only encodes a result when a real App Store
-// has answered it, and a test binary carries no provisioning profile, so
-// `cargo test --features app-store` always takes the error path there.
-//
 // Run with `swift test --package-path backend/storekit`.
 
 @testable import ParqseeStoreKit

--- a/scripts/qa/e2e/README.md
+++ b/scripts/qa/e2e/README.md
@@ -69,7 +69,7 @@ cd backend   && cargo build --example bridge          # the bridge binary
 cd frontend  && pnpm dev                              # keep running, port 1420
 uv run scripts/qa/gen_fixtures.py                     # -> scripts/qa/fixtures/
 cd scripts/qa/e2e && pnpm install                     # playwright-core
-npx --package=playwright-core playwright install webkit   # once per machine
+pnpm exec playwright-core install webkit              # once per machine
 ```
 
 ## Run


### PR DESCRIPTION
PRs currently have no automated application checks. This adds frontend typechecking, production builds and Vitest, plus macOS Clippy and Rust tests with and without StoreKit, Swift payload and callback tests, IPC binding drift detection, and WebKit E2E against the production frontend under the release CSP. The browser error gate is tested by injecting failures before the regression suite runs; results and screenshots are retained for seven days.

An unsigned hosted runner timed out querying live StoreKit entitlements. The three live StoreKit smoke tests are now explicitly opt-in and retain their failure timeouts. CI instead exercises the actual Rust/Swift asynchronous ABI using malformed product input without contacting StoreKit, Rust callback payload ownership and parsing, and Swift success/error callback delivery. App behavior is unchanged; real store integration remains release QA.

Validation: local targeted Rust bridge tests passed (3), Swift tests passed (6), and StoreKit-enabled Clippy passed with warnings denied. Earlier local checks passed frontend build and 276 tests, 107 default Rust tests, both Clippy configurations, actionlint, and CSP E2E with 236 PASS and no failures. Hosted CI passed both jobs on a61e2e6: https://github.com/k0kishima/parqsee/actions/runs/34679857044. Production/CSP E2E reported 236 PASS, 0 FAIL/ERROR and 62 OBSERVE; diagnostics were uploaded successfully.

This covers the pre-release test automation portion of #6. Signing, release uploads, other desktop platforms and repository branch-protection settings are outside this change. Formatting enforcement is deferred because the existing Rust tree does not pass rustfmt.
